### PR TITLE
bug fixing

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileProducing.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileProducing.cs
@@ -47,8 +47,9 @@ namespace OpenRA.Mods.OpenSA.Traits.Conditions
 			: base(info)
 		{
 			var hasCondition = token != Actor.InvalidConditionToken;
-
+			this.self = self;
 			this.info = info;
+			
 			productionQueues = self.Info.TraitInfos<ProductionInfo>().ToArray();
 
 			if (!hasCondition && IsProducing)

--- a/OpenRA.Mods.Common/Traits/MobSpawnerSlave.cs
+++ b/OpenRA.Mods.Common/Traits/MobSpawnerSlave.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.AS.Traits
 	[Desc("Can be slaved to a Mob spawner.")]
 	public class MobSpawnerSlaveInfo : BaseSpawnerSlaveInfo
 	{
-		public override object Create(ActorInitializer init) { return new MobSpawnerSlave(this); }
+		public override object Create(ActorInitializer init) { return new MobSpawnerSlave(init, this); }
 	}
 
 	public class MobSpawnerSlave : BaseSpawnerSlave, INotifySelected
@@ -34,14 +34,13 @@ namespace OpenRA.Mods.AS.Traits
 		public IPositionable Positionable { get; private set; }
 
 		MobSpawnerMaster spawnerMaster;
-		private static ActorInitializer init;
 
 		public bool IsMoving()
 		{
 			return Moves.Any(m => m.IsTraitEnabled() && (m.CurrentMovementTypes.HasFlag(MovementType.Horizontal) || m.CurrentMovementTypes.HasFlag(MovementType.Vertical)));
 		}
 
-		public MobSpawnerSlave(MobSpawnerSlaveInfo info)
+		public MobSpawnerSlave(ActorInitializer init, MobSpawnerSlaveInfo info)
 			: base(init, info)
 		{
 			//// this.info = info;

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -38,14 +38,17 @@ namespace OpenRA.Mods.Common.Warheads
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
+			if (Falloff.Length < 2)
+				throw new YamlException("SpreadDamage requires at least two Falloff values.");
+
 			if (Range != null)
 			{
-				if (Range.Length != 1 && Range.Length != Falloff.Length)
-					throw new YamlException("Number of range values must be 1 or equal to the number of Falloff values.");
+				if (Range.Length != Falloff.Length)
+					throw new YamlException("Number of Range values must be equal to the number of Falloff values.");
 
 				for (var i = 0; i < Range.Length - 1; i++)
-					if (Range[i] > Range[i + 1])
-						throw new YamlException("Range values must be specified in an increasing order.");
+					if (Range[i] >= Range[i + 1])
+						throw new YamlException("Range values must be specified in a strictly increasing order.");
 
 				effectiveRange = Range;
 			}

--- a/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
+++ b/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
@@ -11,11 +11,12 @@
 
 using System.Collections.Immutable;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("This actor makes noise, which causes them to be targeted by actors with the Sandworm trait.")]
-	public class AttractsWormsInfo : ConditionalTraitInfo
+	public class AttractsWormsInfo : ConditionalTraitInfo, IRulesetLoaded<ActorInfo>
 	{
 		[Desc("How much noise this actor produces.")]
 		public readonly int Intensity = 0;
@@ -29,6 +30,21 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Ranges at which each Falloff step is defined. Overrides Spread.")]
 		public readonly ImmutableArray<WDist> Range = default;
 
+		void IRulesetLoaded<ActorInfo>.RulesetLoaded(Ruleset rules, ActorInfo info)
+		{
+			if (Falloff.Length < 2)
+				throw new YamlException("AttractsWorms requires at least two Falloff values.");
+
+			if (Range != null)
+			{
+				if (Range.Length != Falloff.Length)
+					throw new YamlException("Number of Range values must be equal to the number of Falloff values.");
+
+				for (var i = 0; i < Range.Length - 1; i++)
+					if (Range[i] >= Range[i + 1])
+						throw new YamlException("Range values must be specified in a strictly increasing order.");
+			}
+		}
 		public override object Create(ActorInitializer init) { return new AttractsWorms(init, this); }
 	}
 
@@ -70,6 +86,9 @@ namespace OpenRA.Mods.D2k.Traits
 
 			// Actor is too far to hear anything.
 			if (length > effectiveRange[^1].Length)
+				return WVec.Zero;
+
+			if (length == 0)
 				return WVec.Zero;
 
 			var direction = 1024 * distance / length;


### PR DESCRIPTION
OpenRA.Mods.D2k/Traits/AttractsWorms.cs
- Added using OpenRA.Traits; and implemented IRulesetLoaded<ActorInfo> with config validation: Falloff.Length < 2, Range.Length != Falloff.Length, and a strictly-increasing (>=) range check.
- Added a length == 0 guard before the vector-length division.
- Fixes: divide-by-zero crash when a worm sits exactly on a noise emitter; IndexOutOfRangeException from empty Range/Falloff; out-of-bounds Falloff[i] indexing; int2.Lerp divide-by-zero from duplicate range entries. OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
- In RulesetLoaded: added Falloff.Length < 2 guard, tightened Range.Length != Falloff.Length (dropped the == 1 allowance), and changed > to >= in the ordering check.
- Fixes: int2.Lerp divide-by-zero from duplicate ranges; IndexOutOfRangeException from empty Falloff; silent zero-damage on single-entry Range. OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileProducing.cs
- Assigned this.self = self; in the constructor (warning CS0649).
- Fixes: self field never assigned → latent NPE in IsProducing. OpenRA.Mods.Common/Traits/MobSpawnerSlave.cs
- Removed the never-assigned static ActorInitializer init field and forwarded init through the constructor (warning CS0649).
- Fixes: dead/never-assigned static field (a shared-state hazard if ever set); real ActorInitializer now passed correctly.

Thank you for your contribution to OpenRA!

Please be aware that we do not have enough project maintainers to match the rate of contributions, so it may take several days before somebody is able to respond to your Pull Request.

You can help speed up the review process by following a few steps:

* Make sure that you have read and understand the OpenRA Coding Standard (see https://github.com/OpenRA/OpenRA/wiki/Coding-Standard).
* Write quality commit messages (see https://chris.beams.io/posts/git-commit/).
* Only commit changes that directly relate to your Pull Request.  Use your Git interface to unstage any unrelated changes to project files, line endings, whitespace, or other files.
* Review the code diff view below to double check that your changes satisfy the above three points.
* Use the `make test` and `make check` commands to check for (and fix!) any issues that are reported by our automated tests.
* If you are changing shared mod or engine code, make sure that you have tested your changes in all four default mods.
* Respond to review comments as soon as you reasonably can.  Reviewers will usually prioritize Pull Requests that are still fresh in their minds.  Make sure to leave a comment when you push new changes, otherwise GitHub does not automatically notify reviewers!
* Leave a polite comment asking for reviews if a week or more has passed without feedback.

If you need any help you can ask on Discord (https://discord.openra.net) or in the #openra IRC channel on Libera (not as active as Discord).